### PR TITLE
fix: ref() and unref() return this to align with NodeJS Timeout api

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ Timeout.prototype.unref = function() {
     this.unreffed = true
     this.timeout.unref()
   }
+  return this
 }
 
 Timeout.prototype.ref = function() {
@@ -34,6 +35,7 @@ Timeout.prototype.ref = function() {
     this.unreffed = false
     this.timeout.ref()
   }
+  return this
 }
 
 Timeout.prototype.start = function() {
@@ -67,6 +69,7 @@ Interval.prototype.unref = function() {
     this.unreffed = true
     this.timeout.unref()
   }
+  return this
 }
 
 Interval.prototype.ref = function() {
@@ -74,6 +77,7 @@ Interval.prototype.ref = function() {
     this.unreffed = false
     this.timeout.ref()
   }
+  return this
 }
 
 Interval.prototype.start = function() {


### PR DESCRIPTION
Thank you for your work on this module!

## Background

NodeJS' [`Timeout.ref()`](https://nodejs.org/api/timers.html#timeoutref) and [`Timeout.unref()`](https://nodejs.org/api/timers.html#timeoutunref) both return a reference to the `Timeout`.

This allows for doing things like:

```js
const timeout = setTimeout(() => {}, 100).unref()

// later
clearTimeout(timeout)
```

instead of having to call `timeout.unref()` as a separate expression.

## Problem

Since `long-timeout`'s impls of `ref()` and `unref()` return `undefined`, the above usage will result in unexpected behavior -- the timeout is never cleared and will later be invoked (`clearTimeout` will simply noop, if passed anything that is not a timeout)

## Changes

This PR updates `ref()` and `unref()` on `Timeout` and `Interval` to return `this`, such to match NodeJS' api and get `long-timeout` closer to a drop-in replacement (at least w.r.t `ref()` and `unref()`)